### PR TITLE
add coveralls and nyc to .gitignore

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-pro
+repo_token: xb7mdkOt7HvqNT5kHZ0ge3YV0jRJgJfcw

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ node_modules
 # testing
 /coverage
 
+# nyc test coverage
+.nyc_output
+
+#coveralls
+.coveralls.yml
+
 # misc
 .DS_Store
 .env.local
@@ -16,3 +22,5 @@ node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+


### PR DESCRIPTION
Coveralls and nyc_output are now in the .gitignore